### PR TITLE
 Open LinkedIn pages on a new tab #520 

### DIFF
--- a/src/components/SocialMedia/SocialMedia.tsx
+++ b/src/components/SocialMedia/SocialMedia.tsx
@@ -7,18 +7,22 @@ interface SocialMediaProps {
   color: SocialMediaColor;
   link: string;
   icon: IconDefinition;
+  target?: string;
 }
 
 const SocialMedia = (props: SocialMediaProps) => {
-  return (
-    props.link === " " ? 
-      <SocialMediaIcon color={props.color}>
-        <FontAwesomeIcon icon={props.icon} size="3x" />
-      </SocialMediaIcon>
-      :
-      <SocialMediaIcon color={props.color} href={props.link}>
-        <FontAwesomeIcon icon={props.icon} size="3x" />
-      </SocialMediaIcon>
+  return props.link === " " ? (
+    <SocialMediaIcon color={props.color}>
+      <FontAwesomeIcon icon={props.icon} size="3x" />
+    </SocialMediaIcon>
+  ) : (
+    <SocialMediaIcon
+      color={props.color}
+      href={props.link}
+      target={props.target}
+    >
+      <FontAwesomeIcon icon={props.icon} size="3x" />
+    </SocialMediaIcon>
   );
 };
 

--- a/src/components/TeamSection/Profile.tsx
+++ b/src/components/TeamSection/Profile.tsx
@@ -6,7 +6,6 @@ import SocialMedia from "components/SocialMedia/SocialMedia";
 import { SocialMediaColor } from "../../utility/SharedStyles";
 import { faLinkedinIn } from "@fortawesome/free-brands-svg-icons";
 
-
 // props for team profile
 type ProfileProps = {
   key: number;
@@ -17,12 +16,9 @@ type ProfileProps = {
   isExec: boolean;
 };
 
-
-
 const Profile = (props: ProfileProps) => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const preventDragHandler = (e: any) => e.preventDefault();
-
 
   return (
     <S.ProfileDiv
@@ -40,7 +36,6 @@ const Profile = (props: ProfileProps) => {
       </S.ProfileIconDiv>
 
       <S.LinksSection
-
         backgroundColor={
           props.isExec
             ? SocialMediaColor.ToggleGreen
@@ -51,6 +46,7 @@ const Profile = (props: ProfileProps) => {
           color={SocialMediaColor.White}
           icon={faLinkedinIn}
           link={props.member.linkedin}
+          target="_blank"
         />
       </S.LinksSection>
 


### PR DESCRIPTION
LinkedIn links in the team page now open on a new tab, rather than loading directly in the website.